### PR TITLE
Correctly pass specified messageType to base function

### DIFF
--- a/src/Intercom/Data/AdminConversationReply.cs
+++ b/src/Intercom/Data/AdminConversationReply.cs
@@ -30,7 +30,7 @@ namespace Intercom.Data
                                       String messageType = Reply.ReplyMessageType.COMMENT,
                                       String body = "",
                                       List<String> attachementUrls = null)
-            : base(conversationId, Reply.ReplyMessageType.COMMENT, body, attachementUrls)
+            : base(conversationId, messageType, body, attachementUrls)
         {
 
             if (String.IsNullOrEmpty(conversationId))


### PR DESCRIPTION
base function hardcoded to set message type as `Reply.ReplyMessageType.COMMENT`. 
Fix to allow passing specified message type to the base function. Was causing an issue when trying to assign a conversation to another admin