### PR TITLE
fix (company): changed company.plan to string

### DIFF
--- a/src/Intercom/Clients/CompanyClient.cs
+++ b/src/Intercom/Clients/CompanyClient.cs
@@ -188,18 +188,13 @@ namespace Intercom.Clients
 
         private String Transform (Company company)
         {
-            String plan = String.Empty;
-
-            if (company.plan != null)
-                plan = company.plan.name;
-
             var body = new {
                 remote_created_at = company.remote_created_at,
                 company_id = company.company_id,
                 name = company.name,
                 monthly_spend = company.monthly_spend,
                 custom_attributes = company.custom_attributes,
-                plan = plan
+                plan = company.plan
             };
 
             return JsonConvert.SerializeObject (body,

--- a/src/Intercom/Data/Company.cs
+++ b/src/Intercom/Data/Company.cs
@@ -15,7 +15,7 @@ namespace Intercom.Data
 	{
 		public bool? remove { set; get; }
 		public string name { get; set; }
-		public Plan plan { get; set; }
+		public string plan { get; set; }
 		public string company_id { get; set; }
 		public long? remote_created_at { get; set; }
 		public long? created_at { get; set; }

--- a/src/Intercom/Data/Plan.cs
+++ b/src/Intercom/Data/Plan.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 using Intercom.Core;
 using Intercom.Data;
 
@@ -10,9 +11,15 @@ using Intercom.Exceptions;
 
 namespace Intercom.Data
 {
+	[JsonConverter(typeof(PlanJsonConverter))]
 	public class Plan : Model
 	{
 		public string name { get; set; }
+
+		public override string ToString()
+		{
+			return this.name;
+		}
 	}
 }
 

--- a/src/Intercom/Data/PlanJsonConverter.cs
+++ b/src/Intercom/Data/PlanJsonConverter.cs
@@ -1,0 +1,35 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Intercom.Data
+{
+    public class PlanJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            Plan plan = value as Plan;
+
+            writer.WriteValue(plan.name);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            Dictionary<string, object> values = serializer.Deserialize<Dictionary<string, object>>(reader);
+
+            Plan plan = new Plan();
+
+            plan.id = values["id"] as string;
+            plan.type = values["type"] as string;
+            plan.name = values["name"] as string;
+
+            return plan;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Plan);
+        }
+    }
+}

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Data\Tags.cs" />
     <Compile Include="Data\Users.cs" />
     <Compile Include="Data\Plan.cs" />
+    <Compile Include="Data\PlanJsonConverter.cs" />
     <Compile Include="Exceptions\IntercomException.cs" />
     <Compile Include="Core\Constants.cs" />
     <Compile Include="Data\Error.cs" />


### PR DESCRIPTION
company.plan was a Plan object in this library. The API has it as a
string value. Changed library to match API.