### PR TITLE
Enable removal of company from user on update

### DIFF
--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -417,8 +417,8 @@ namespace Intercom.Clients
                     name = c.name,
                     monthly_spend = c.monthly_spend,
                     custom_attributes = c.custom_attributes,
-                    plan = c.plan != null ? c.plan.name : String.Empty
-
+                    plan = c.plan != null ? c.plan.name : String.Empty,
+                    remove = c.remove
                 }).ToList();
             }
             else


### PR DESCRIPTION
Fixes #92.
Previously the only way you could remove a user from a company was to
use the provided methods. Adding the remove property to the company when
updating a user allows this to be done when updating the user,
preventing the need for two separate calls.
Have not created or updated any tests since there aren't any currently.
As such I have reduced my scope of impact by only changing the code
which is strictly necessary.