### PR TITLE
Target .NET Standard

### DIFF
--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ReleaseVersion>2.0.0</ReleaseVersion>
   </PropertyGroup>
 

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="RestSharp" Version="106.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>


### PR DESCRIPTION
This PR changes the target from .NET Core App 2.0 to .NET Standard 2.0. This should correct #115. It also removes the dependency to the test SDK, which isn't required by the core library. With that dependency in place, NuGet forwards that dependency on to consumers of the package.