### PR TITLE
Use DateTimeOffset Instead of Int64/long for Dates

### DIFF
--- a/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
+++ b/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
@@ -14,6 +14,7 @@ namespace Intercom.Tests.Converters.ClassConverters
     {
         private const string _DateCreatedISO = "1989-04-16T00:15:00Z";
         private const string _DateCreatedUnix = "608688900";
+        private const string _Null = "null";
 
         private readonly DateTimeJsonConverter _converter;
 
@@ -31,6 +32,30 @@ namespace Intercom.Tests.Converters.ClassConverters
                 DateTime dateCreated = (DateTime)_converter.ReadJson(jsonReader, typeof(DateTime), null, null);
 
                 Assert.AreEqual(_ParseUtcDateString(_DateCreatedISO), dateCreated);
+            }
+        }
+
+        [TestCase(_Null)]
+        public void ReadJson_ForNullableDateTime_ReturnsNull(string json)
+        {
+            using (StringReader stringReader = new StringReader(json))
+            using (JsonReader jsonReader = new JsonTextReader(stringReader))
+            {
+                DateTime? dateCreated = (DateTime?)_converter.ReadJson(jsonReader, typeof(DateTime?), null, null);
+
+                Assert.AreEqual(null, dateCreated);
+            }
+        }
+
+        [TestCase(null)]
+        public void WriteJsonForNullableDateTime_ReturnsNull(DateTime? input)
+        {
+            using (StringWriter stringWriter = new StringWriter())
+            using (JsonWriter jsonWriter = new JsonTextWriter(stringWriter))
+            {
+                _converter.WriteJson(jsonWriter, input, null);
+
+                Assert.AreEqual(_Null, stringWriter.GetStringBuilder().ToString());
             }
         }
 

--- a/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
+++ b/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+using Intercom.Test;
+using NUnit.Framework;
+
+namespace Intercom.Tests.Converters.ClassConverters
+{
+    [TestFixture]
+    public class DateTimeJsonConverterTest : TestBase
+    {
+        [Test]
+        public void ReadJson_ForDateTime_ReturnsValidDateTime()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Test]
+        public void WriteJson_ForDateTime_ReturnsValidUnixTimestamp()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
+++ b/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
@@ -1,17 +1,34 @@
 ﻿using System;
+using System.IO;
 
 using Intercom.Test;
+using Newtonsoft.Json;
 using NUnit.Framework;
+
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Tests.Converters.ClassConverters
 {
     [TestFixture]
     public class DateTimeJsonConverterTest : TestBase
     {
-        [Test]
-        public void ReadJson_ForDateTime_ReturnsValidDateTime()
+        private readonly DateTimeJsonConverter _converter;
+
+        public DateTimeJsonConverterTest()
         {
-            throw new NotImplementedException();
+            _converter = new DateTimeJsonConverter();
+        }
+
+        [TestCase("608688900")]
+        public void ReadJson_ForDateTime_ReturnsValidDateTime(string json)
+        {
+            using (StringReader stringReader = new StringReader(json))
+            using (JsonReader jsonReader = new JsonTextReader(stringReader))
+            {
+                DateTime dateCreated = (DateTime)_converter.ReadJson(jsonReader, typeof(DateTime), null, null);
+
+                Assert.AreEqual(new DateTime(1989, 4, 16, 0, 15, 0), dateCreated);
+            }
         }
 
         [Test]

--- a/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
+++ b/src/Intercom.Tests/Converters/ClassConverters/DateTimeJsonConverterTest.cs
@@ -12,6 +12,9 @@ namespace Intercom.Tests.Converters.ClassConverters
     [TestFixture]
     public class DateTimeJsonConverterTest : TestBase
     {
+        private const string _DateCreatedISO = "1989-04-16T00:15:00Z";
+        private const string _DateCreatedUnix = "608688900";
+
         private readonly DateTimeJsonConverter _converter;
 
         public DateTimeJsonConverterTest()
@@ -19,7 +22,7 @@ namespace Intercom.Tests.Converters.ClassConverters
             _converter = new DateTimeJsonConverter();
         }
 
-        [TestCase("608688900")]
+        [TestCase(_DateCreatedUnix)]
         public void ReadJson_ForDateTime_ReturnsValidDateTime(string json)
         {
             using (StringReader stringReader = new StringReader(json))
@@ -27,14 +30,37 @@ namespace Intercom.Tests.Converters.ClassConverters
             {
                 DateTime dateCreated = (DateTime)_converter.ReadJson(jsonReader, typeof(DateTime), null, null);
 
-                Assert.AreEqual(new DateTime(1989, 4, 16, 0, 15, 0), dateCreated);
+                Assert.AreEqual(_ParseUtcDateString(_DateCreatedISO), dateCreated);
             }
         }
 
-        [Test]
-        public void WriteJson_ForDateTime_ReturnsValidUnixTimestamp()
+        [TestCase(_DateCreatedISO)]
+        public void WriteJson_ForDateTime_ReturnsValidUnixTimestamp(string input)
         {
-            throw new NotImplementedException();
+            DateTime inputDate;
+
+            try
+            {
+                inputDate = _ParseUtcDateString(input);
+            }
+
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to properly parse the test input.", ex);
+            }
+
+            using (StringWriter stringWriter = new StringWriter())
+            using (JsonWriter jsonWriter = new JsonTextWriter(stringWriter))
+            {
+                _converter.WriteJson(jsonWriter, inputDate, null);
+
+                Assert.AreEqual(_DateCreatedUnix, stringWriter.GetStringBuilder().ToString());
+            }
+        }
+
+        private DateTime _ParseUtcDateString(string input)
+        {
+            return DateTimeOffset.Parse(input).UtcDateTime;
         }
     }
 }

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -240,7 +240,7 @@ namespace Intercom.Clients
             return result.Result;
         }
 
-        public User UpdateLastSeenAt(String id, DateTime timestamp)
+        public User UpdateLastSeenAt(String id, DateTimeOffset timestamp)
         {
             if (String.IsNullOrEmpty(id))
             {
@@ -253,7 +253,7 @@ namespace Intercom.Clients
             return result.Result;
         }
 
-        public User UpdateLastSeenAt(User user, DateTime timestamp)
+        public User UpdateLastSeenAt(User user, DateTimeOffset timestamp)
         {
             if (user == null)
             {

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -240,16 +240,11 @@ namespace Intercom.Clients
             return result.Result;
         }
 
-        public User UpdateLastSeenAt(String id, long timestamp)
+        public User UpdateLastSeenAt(String id, DateTime timestamp)
         {
             if (String.IsNullOrEmpty(id))
             {
                 throw new ArgumentNullException(nameof(id));
-            }
-
-            if (timestamp <= 0)
-            {
-                throw new ArgumentException("'timestamp' argument should be bigger than zero.");
             }
 
             ClientResponse<User> result = null;
@@ -258,16 +253,11 @@ namespace Intercom.Clients
             return result.Result;
         }
 
-        public User UpdateLastSeenAt(User user, long timestamp)
+        public User UpdateLastSeenAt(User user, DateTime timestamp)
         {
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));
-            }
-
-            if (timestamp <= 0)
-            {
-                throw new ArgumentException("'timestamp' argument should be bigger than zero.");
             }
 
             String body = String.Empty;

--- a/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
+++ b/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
@@ -4,11 +4,11 @@ using Newtonsoft.Json;
 
 namespace Intercom.Converters.ClassConverters
 {
-    public class DateTimeJsonConverter : JsonConverter
+    public class DateTimeOffsetJsonConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
-            return (objectType.Equals(typeof(DateTime)) || objectType.Equals(typeof(DateTime?)));
+            return (objectType.Equals(typeof(DateTimeOffset)) || objectType.Equals(typeof(DateTimeOffset?)));
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -34,8 +34,8 @@ namespace Intercom.Converters.ClassConverters
                 throw new FormatException("Dates must be represented as UNIX timestamps in JSON.", ex);
             }
 
-            DateTime unixEpoch = new DateTime(1970, 1, 1);
-            DateTime result = unixEpoch.AddSeconds(unixTimestamp);
+            DateTimeOffset unixEpoch = _GetUnixEpoch();
+            DateTimeOffset result = unixEpoch.AddSeconds(unixTimestamp);
 
             return result;
         }
@@ -49,12 +49,19 @@ namespace Intercom.Converters.ClassConverters
                 return;
             }
 
-            DateTime unixEpoch = new DateTime(1970, 1, 1);
-            DateTime dateTime = (DateTime)value;
+            DateTimeOffset unixEpoch = _GetUnixEpoch();
+            DateTimeOffset dateTimeOffset = (DateTimeOffset)value;
 
-            long unixTimestamp = Convert.ToInt64((dateTime - unixEpoch).TotalSeconds);
+            dateTimeOffset = dateTimeOffset.ToOffset(TimeSpan.Zero);
+
+            long unixTimestamp = Convert.ToInt64((dateTimeOffset - unixEpoch).TotalSeconds);
 
             writer.WriteRawValue(unixTimestamp.ToString());
+        }
+
+        private DateTimeOffset _GetUnixEpoch()
+        {
+            return new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
         }
     }
 }

--- a/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
+++ b/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
@@ -33,7 +33,12 @@ namespace Intercom.Converters.ClassConverters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            DateTime unixEpoch = new DateTime(1970, 1, 1);
+            DateTime dateTime = (DateTime)value;
+
+            long unixTimestamp = Convert.ToInt64((dateTime - unixEpoch).TotalSeconds);
+
+            writer.WriteRawValue(unixTimestamp.ToString());
         }
     }
 }

--- a/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
+++ b/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using Newtonsoft.Json;
+
+namespace Intercom.Converters.ClassConverters
+{
+    public class DateTimeJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.Equals(typeof(DateTime));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            long unixTimestamp;
+
+            try
+            {
+                unixTimestamp = Convert.ToInt64(reader.ReadAsDouble());
+            }
+
+            catch (InvalidCastException ex)
+            {
+                throw new FormatException("Dates must be represented as UNIX timestamps in JSON.", ex);
+            }
+
+            DateTime unixEpoch = new DateTime(1970, 1, 1);
+            DateTime result = unixEpoch.AddSeconds(unixTimestamp);
+
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
+++ b/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
@@ -13,8 +13,6 @@ namespace Intercom.Converters.ClassConverters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            reader.Read();
-
             object value = reader.Value;
 
             if (value == null)

--- a/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
+++ b/src/Intercom/Converters/ClassConverters/DateTimeJsonConverter.cs
@@ -8,16 +8,25 @@ namespace Intercom.Converters.ClassConverters
     {
         public override bool CanConvert(Type objectType)
         {
-            return objectType.Equals(typeof(DateTime));
+            return (objectType.Equals(typeof(DateTime)) || objectType.Equals(typeof(DateTime?)));
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            reader.Read();
+
+            object value = reader.Value;
+
+            if (value == null)
+            {
+                return null;
+            }
+
             long unixTimestamp;
 
             try
             {
-                unixTimestamp = Convert.ToInt64(reader.ReadAsDouble());
+                unixTimestamp = Convert.ToInt64(value);
             }
 
             catch (InvalidCastException ex)
@@ -33,6 +42,13 @@ namespace Intercom.Converters.ClassConverters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
+            if (value == null)
+            {
+                writer.WriteRawValue("null");
+
+                return;
+            }
+
             DateTime unixEpoch = new DateTime(1970, 1, 1);
             DateTime dateTime = (DateTime)value;
 

--- a/src/Intercom/Data/Company.cs
+++ b/src/Intercom/Data/Company.cs
@@ -3,6 +3,7 @@ using Intercom.Core;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Intercom.Converters.AttributeConverters;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
@@ -12,10 +13,14 @@ namespace Intercom.Data
         public string name { get; set; }
         public Plan plan { get; set; }
         public string company_id { get; set; }
-        public long? remote_created_at { get; set; }
-        public long? created_at { get; set; }
-        public long? updated_at { get; set; }
-        public long? last_request_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? remote_created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? last_request_at { get; set; }
         public int? monthly_spend { get; set; }
         public int? session_count { get; set; }
         public int? user_count { get; set; }

--- a/src/Intercom/Data/Company.cs
+++ b/src/Intercom/Data/Company.cs
@@ -13,14 +13,14 @@ namespace Intercom.Data
         public string name { get; set; }
         public Plan plan { get; set; }
         public string company_id { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? remote_created_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? created_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? updated_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? last_request_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? remote_created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? last_request_at { get; set; }
         public int? monthly_spend { get; set; }
         public int? session_count { get; set; }
         public int? user_count { get; set; }

--- a/src/Intercom/Data/Conversation.cs
+++ b/src/Intercom/Data/Conversation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Intercom.Clients;
 using Intercom.Converters.AttributeConverters;
+using Intercom.Converters.ClassConverters;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
@@ -11,10 +12,14 @@ namespace Intercom.Data
 {
     public class Conversation : Model
     {
-        public long created_at { get; set; }
-        public long updated_at { get; set; }
-        public long? waiting_since { get; set; }
-        public long? snoozed_until { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? waiting_since { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? snoozed_until { get; set; }
         public Assignee assignee { get; set; }
         public User user { get; set; }
         public bool open { get; set; }

--- a/src/Intercom/Data/Conversation.cs
+++ b/src/Intercom/Data/Conversation.cs
@@ -12,14 +12,14 @@ namespace Intercom.Data
 {
     public class Conversation : Model
     {
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime created_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime updated_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? waiting_since { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? snoozed_until { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? waiting_since { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? snoozed_until { get; set; }
         public Assignee assignee { get; set; }
         public User user { get; set; }
         public bool open { get; set; }

--- a/src/Intercom/Data/ConversationPart.cs
+++ b/src/Intercom/Data/ConversationPart.cs
@@ -4,6 +4,8 @@ using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
@@ -11,9 +13,12 @@ namespace Intercom.Data
     {
         public string part_type { get; set; }
         public string body { get; set; }
-        public long created_at { get; set; }
-        public long updated_at { get; set; }
-        public long notified_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime notified_at { get; set; }
         public Assignee assigned_to { get; set; }
         public Author author { get; set; }
         public List<Attachment> attachments { get; set; }

--- a/src/Intercom/Data/ConversationPart.cs
+++ b/src/Intercom/Data/ConversationPart.cs
@@ -13,12 +13,12 @@ namespace Intercom.Data
     {
         public string part_type { get; set; }
         public string body { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime created_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime updated_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime notified_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset notified_at { get; set; }
         public Assignee assigned_to { get; set; }
         public Author author { get; set; }
         public List<Attachment> attachments { get; set; }

--- a/src/Intercom/Data/Event.cs
+++ b/src/Intercom/Data/Event.cs
@@ -13,8 +13,8 @@ namespace Intercom.Data
 	public class Event : Model
 	{
 		public string event_name { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? created_at { get; set; }
 		public string user_id { get; set; }
 		public string email { get; set; }
 

--- a/src/Intercom/Data/Event.cs
+++ b/src/Intercom/Data/Event.cs
@@ -6,13 +6,15 @@ using Intercom.Exceptions;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Intercom.Converters.AttributeConverters;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
 	public class Event : Model
 	{
 		public string event_name { get; set; }
-		public long? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? created_at { get; set; }
 		public string user_id { get; set; }
 		public string email { get; set; }
 

--- a/src/Intercom/Data/Note.cs
+++ b/src/Intercom/Data/Note.cs
@@ -3,12 +3,15 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Newtonsoft.Json;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
     public class Note : Model
     {
-        public long? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? created_at { get; set; }
         public string body { get; set; }
         public Admin author { get; set; }
         public User user { get; set; }

--- a/src/Intercom/Data/Note.cs
+++ b/src/Intercom/Data/Note.cs
@@ -10,8 +10,8 @@ namespace Intercom.Data
 {
     public class Note : Model
     {
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? created_at { get; set; }
         public string body { get; set; }
         public Admin author { get; set; }
         public User user { get; set; }

--- a/src/Intercom/Data/Segment.cs
+++ b/src/Intercom/Data/Segment.cs
@@ -6,15 +6,18 @@ using Intercom.Data;
 using Intercom.Clients;
 
 using Intercom.Exceptions;
-
+using Newtonsoft.Json;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
 	public class Segment : Model
 	{
         public string name { get; set; }
-        public long created_at { get; set; }
-        public long updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime updated_at { get; set; }
 
 		public Segment ()
 		{

--- a/src/Intercom/Data/Segment.cs
+++ b/src/Intercom/Data/Segment.cs
@@ -14,10 +14,10 @@ namespace Intercom.Data
 	public class Segment : Model
 	{
         public string name { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime created_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset updated_at { get; set; }
 
 		public Segment ()
 		{

--- a/src/Intercom/Data/User.cs
+++ b/src/Intercom/Data/User.cs
@@ -13,16 +13,16 @@ namespace Intercom.Data
 		public string email { get; set; }
 		public string phone { get; set; }
 		public string name { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? updated_at { get; set; }
 		public string last_seen_ip { get; set; }
 		public bool? unsubscribed_from_emails { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? last_request_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? signed_up_at { get; set; }
-        [JsonConverter(typeof(DateTimeJsonConverter))]
-        public DateTime? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? last_request_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? signed_up_at { get; set; }
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
+        public DateTimeOffset? created_at { get; set; }
 		public int? session_count { get; set; }
         public bool? new_session { get; set; }
 		public string user_agent_data { get; set; }

--- a/src/Intercom/Data/User.cs
+++ b/src/Intercom/Data/User.cs
@@ -3,6 +3,7 @@ using Intercom.Core;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Intercom.Converters.AttributeConverters;
+using Intercom.Converters.ClassConverters;
 
 namespace Intercom.Data
 {
@@ -12,12 +13,16 @@ namespace Intercom.Data
 		public string email { get; set; }
 		public string phone { get; set; }
 		public string name { get; set; }
-		public long? updated_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? updated_at { get; set; }
 		public string last_seen_ip { get; set; }
 		public bool? unsubscribed_from_emails { get; set; }
-		public long? last_request_at { get; set; }
-		public long? signed_up_at { get; set; }
-		public long? created_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? last_request_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? signed_up_at { get; set; }
+        [JsonConverter(typeof(DateTimeJsonConverter))]
+        public DateTime? created_at { get; set; }
 		public int? session_count { get; set; }
         public bool? new_session { get; set; }
 		public string user_agent_data { get; set; }


### PR DESCRIPTION
I've found myself adding helper classes to convert the UNIX timestamps in the Intercom models to `DateTime` objects for use with our business logic. This PR changes all `Int64`/`long` implementations in the models to `DateTimeOffset` (or `DateTimeOffset?` where applicable) and implements a JsonConverter to ensure dates are always represented as UNIX timestamps in UTC when serialized to JSON for the API.

If this PR doesn't align with the direction of the project, feel free to simply close it. I just wanted to share in case anyone found it useful. Thanks!