### PR TITLE
Configure project to build NuGet package

### DIFF
--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -3,10 +3,20 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ReleaseVersion>2.0.0</ReleaseVersion>
+    <PackageId>Intercom.Dotnet.Client</PackageId>
+    <PackageVersion>2.0.0</PackageVersion>
+    <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
+    <Owners>Intercom</Owners>
+    <PackageProjectUrl>https://github.com/intercom/intercom-dotnet</PackageProjectUrl>
+    <Summary>The official Intercom API client library for .NET</Summary>
+    <Title>Intercom Dotnet Client</Title>
+    <Description>The official Intercom API client library for .NET</Description>
+    <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="106.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I think this should address https://github.com/intercom/intercom-dotnet/issues/115

Did some testing including creating my own test MyGet instance that publishes to NuGet (using my own test NuGet packages) and my dependencies resolve correctly

I believe this renders the existing `Intercom.nuspec` file obsolete as it uses the metadata in the `Intercom.csproj` file 

Set up metadata using Visual Studio for Mac shown below
![image](https://user-images.githubusercontent.com/892961/39674509-8c5e1c20-517f-11e8-95e8-4971dff18296.png)
