### PR TITLE
fixing project version

### DIFF
--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ReleaseVersion>2.0.0</ReleaseVersion>
     <PackageId>Intercom.Dotnet.Client</PackageId>
-    <PackageVersion>2.0.0</PackageVersion>
     <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
     <Owners>Intercom</Owners>
     <PackageProjectUrl>https://github.com/intercom/intercom-dotnet</PackageProjectUrl>


### PR DESCRIPTION
In the previous PR we have accidentally made the package to be at version 2.0.0. We don't need to pass in a package version as our Nuget build will automatically patch the necessary files with that information.