### PR TITLE
changed monthly_spend to decimal

### DIFF
--- a/src/Intercom/Data/Company.cs
+++ b/src/Intercom/Data/Company.cs
@@ -16,7 +16,7 @@ namespace Intercom.Data
         public long? created_at { get; set; }
         public long? updated_at { get; set; }
         public long? last_request_at { get; set; }
-        public int? monthly_spend { get; set; }
+        public decimal? monthly_spend { get; set; }
         public int? session_count { get; set; }
         public int? user_count { get; set; }
         public int? size { get; set; }


### PR DESCRIPTION
Even though Intercom will truncate decimals...

![image](https://user-images.githubusercontent.com/11810153/41493569-6562f870-7100-11e8-8e67-fa2d7010f9a6.png)

...we should keep type consistency with the model available in the docs.

Closes #117 
