### PR TITLE
Updated model for conversation replys.

### DIFF
--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -27,16 +27,16 @@ namespace Intercom.Clients
         {
         }
 
-        public ConversationPart Reply(AdminConversationReply reply)
+        public Conversation Reply(AdminConversationReply reply)
         {
             if (reply == null)
             {
                 throw new ArgumentNullException(nameof(reply));
             }
 
-            ClientResponse<ConversationPart> result = null;
+            ClientResponse<Conversation> result = null;
             String body = Serialize<AdminConversationReply>(reply);
-            result = Post<ConversationPart>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
+            result = Post<Conversation>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
             return result.Result;
         }
 

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -28,16 +28,16 @@ namespace Intercom.Clients
         {
         }
 
-        public ConversationPart Reply(UserConversationReply reply)
+        public Conversation Reply(UserConversationReply reply)
         {
             if (reply == null)
             {
                 throw new ArgumentNullException(nameof(reply));
             }
 
-            ClientResponse<ConversationPart> result = null;
+            ClientResponse<Conversation> result = null;
             String body = Serialize<UserConversationReply>(reply);
-            result = Post<ConversationPart>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
+            result = Post<Conversation>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
             return result.Result;
         }
 


### PR DESCRIPTION
#### Why?
Updated model that's returned when replying to a message.

See [Docs](https://developers.intercom.com/intercom-api-reference/reference#replying-to-a-conversation)

#### How?
Simply changed the return value to be a a `Conversation` vs a `ConversationPart` as the documentation expects. 
