### PR TITLE
Updated Conversation Reply Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ AdminConversationMessage admin_message =
 
 **Create Admin initiated Conversation's reply**
 ```cs
-AdminConversationReply admin_reply =
+Conversation conversation =
     adminConversationsClient.Reply(
         new AdminConversationReply(
             conversationId: "1000_conversation_id",
@@ -537,7 +537,7 @@ UserConversationMessage user_message =
 
 **Create User initiated Conversation's reply**
 ```cs
-UserConversationReply user_reply =
+Conversation conversation =
     userConversationsClient.Reply(
         new UserConversationReply(
             conversationId: "1000_conversation_id",

--- a/src/Intercom.Tests/Data/AdminConversationReplyTest.cs
+++ b/src/Intercom.Tests/Data/AdminConversationReplyTest.cs
@@ -1,12 +1,34 @@
-﻿using System;
+﻿using Intercom.Clients;
+using Intercom.Core;
+using Intercom.Data;
+using NUnit.Framework;
+using System.Net;
 
 namespace Intercom.Test
 {
-    // TODO: write tests for AdminConversationReplyTest
-    public class AdminConversationReplyTest
+    [TestFixture]
+    public class AdminConversationReplyTest : TestBase
     {
-        public AdminConversationReplyTest()
+        [Test]
+        public void AdminConversationReply()
         {
+            var mock = BuildMockClient<AdminConversationsClient, Conversation>(HttpStatusCode.OK, "Conversation.json", new Authentication(AppId, AppKey));
+
+            var convo = mock.Reply(new AdminConversationReply("147", "25", "comment", "We noticed you using our Product,  do you have any questions?"));
+
+            Assert.IsNotNull(convo);
+            Assert.IsTrue(convo.conversation_message.body.Contains("We noticed you using our Product"));
+        }
+
+        [Test]
+        public void ListAdminConversations()
+        {
+            var mock = BuildSuccessMockClient<AdminConversationsClient, Conversation>("ConversationsList.json", new Authentication(AppId, AppKey));
+
+            var convo = mock.List(new Admin() { id = "394051" });
+
+            Assert.IsNotNull(convo);
+            Assert.AreEqual(1, convo.conversations.Count);
         }
     }
 }

--- a/src/Intercom.Tests/Data/Responses/Conversation.json
+++ b/src/Intercom.Tests/Data/Responses/Conversation.json
@@ -1,0 +1,51 @@
+{
+  "type": "conversation",
+  "id": "147",
+  "created_at": 1400850973,
+  "updated_at": 1400857494,
+  "waiting_since": 1400857494,
+  "snoozed_until": null,
+  "conversation_message": {
+    "type": "conversation_message",
+    "subject": "",
+    "body": "<p>Hi Alice,</p>\n\n<p> We noticed you using our Product,  do you have any questions?</p> \n<p>- Jane</p>",
+    "author": {
+      "type": "admin",
+      "id": "25"
+    },
+    "attachments": [
+      {
+        "name": "signature",
+        "url": "http://example.org/signature.jpg"
+      }
+    ]
+  },
+  "user": {
+    "type": "user",
+    "id": "536e564f316c83104c000020"
+  },
+  "customers": [
+    {
+      "type": "user",
+      "id": "58ff3f670f14ab4f1aa83750"
+    }
+  ],
+  "assignee": {
+    "type": "admin",
+    "id": "25"
+  },
+  "open": true,
+  "state": "open",
+  "read": true,
+  "conversation_parts": {
+    "type": "conversation_part.list",
+    "conversation_parts": [
+      //... List of conversation parts
+    ],
+    "total_count": 1
+  },
+  "tags": {
+    "type": "tag.list",
+    "tags": []
+  }
+}

--- a/src/Intercom.Tests/Data/Responses/ConversationsList.json
+++ b/src/Intercom.Tests/Data/Responses/ConversationsList.json
@@ -1,0 +1,49 @@
+{
+    "type": "conversation.list",
+    "pages": {
+        "type": "pages",
+        "next": "https://api.intercom.io/conversations?per_page=20&page=2",
+        "page": 1,
+        "per_page": 20,
+        "total_pages": 40
+    },
+    "conversations": [
+        {
+            "type": "conversation",
+            "id": "13257844375",
+            "created_at": 1507709579,
+            "updated_at": 1507709579,
+            "waiting_since": 1507709579,
+            "snoozed_until": null,
+            "user": {
+                "type": "user",
+                "id": "5813655e889f1c9e64a1155b"
+            },
+            "customers": [
+                {
+                    "type": "user",
+                    "id": "5813655e889f1c9e64a1155b"
+                }
+            ],
+            "assignee": {
+                "type": "nobody_admin",
+                "id": null
+            },
+            "conversation_message": {
+                "type": "conversation_message",
+                "id": "139303349",
+                "subject": "",
+                "body": "<p>test msg</p>",
+                "author": {
+                    "type": "user",
+                    "id": "5813655e889f1c9e64a1155b"
+                },
+                "attachments": [],
+                "url": "https://test.com/index.html"
+            },
+            "open": true,
+            "state": "open",
+            "read": true
+        }
+    ]
+}

--- a/src/Intercom.Tests/Data/UserConversationReplyTest.cs
+++ b/src/Intercom.Tests/Data/UserConversationReplyTest.cs
@@ -1,12 +1,37 @@
-﻿using System;
+﻿using Intercom.Clients;
+using Intercom.Core;
+using Intercom.Data;
+using NUnit.Framework;
 
 namespace Intercom.Test
 {
-    // TODO: write tests for UserConversationReply 
-    public class UserConversationReplyTest
+    [TestFixture]
+    public class UserConversationReplyTest : TestBase
     {
         public UserConversationReplyTest()
         {
+        }
+
+        [Test]
+        public void UserConverstationReply()
+        {
+            var mock = BuildSuccessMockClient<UserConversationsClient, Conversation>("Conversation.json", new Authentication(AppId, AppKey));
+
+            var convo = mock.Reply(new UserConversationReply("147", "We noticed you using our Product,  do you have any questions?", "536e564f316c83104c000020"));
+
+            Assert.IsNotNull(convo);
+            Assert.IsTrue(convo.conversation_message.body.Contains("We noticed you using our Product"));
+        }
+
+        [Test]
+        public void ListUserConversations()
+        {
+            var mock = BuildSuccessMockClient<UserConversationsClient, Conversation>("ConversationsList.json", new Authentication(AppId, AppKey));
+
+            var convo = mock.List("536e564f316c83104c000020");
+
+            Assert.IsNotNull(convo);
+            Assert.AreEqual(1, convo.conversations.Count);
         }
     }
 }

--- a/src/Intercom.Tests/Intercom.Tests.csproj
+++ b/src/Intercom.Tests/Intercom.Tests.csproj
@@ -16,4 +16,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Intercom\Intercom.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="Data\Responses\Conversation.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Data\Responses\ConversationsList.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Intercom.Tests/TestBase.cs
+++ b/src/Intercom.Tests/TestBase.cs
@@ -1,6 +1,12 @@
 ﻿using System;
-using NUnit.Framework;
 using Intercom.Core;
+using RestSharp;
+using System.Net;
+using Newtonsoft.Json;
+using Moq;
+using Moq.Protected;
+using System.IO;
+using NUnit.Framework;
 
 namespace Intercom.Test
 {
@@ -11,6 +17,37 @@ namespace Intercom.Test
 
         public TestBase()
         {
+        }
+
+        
+        private static IRestClient MockRestClient<T>(HttpStatusCode httpStatusCode, string jsonFile) where T : new()
+        {
+            var json = File.ReadAllText(Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "Responses", jsonFile));
+            var data = JsonConvert.DeserializeObject<T>(json);
+            var response = new Mock<IRestResponse<T>>();
+            response.Setup(_ => _.StatusCode).Returns(httpStatusCode);
+            response.Setup(_ => _.Data).Returns(data);
+            response.Setup(_ => _.Content).Returns(json);
+
+            var mockIRestClient = new Mock<IRestClient>();
+            mockIRestClient
+                .Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(response.Object);
+
+            return mockIRestClient.Object;
+        }
+
+        protected static TClient BuildMockClient<TClient, TResult>(HttpStatusCode httpStatusCode, string jsonResultFile, params object[] ctorArgs) where TResult : new() where TClient : Client
+        {
+            var result = MockRestClient<TResult>(httpStatusCode, jsonResultFile);
+            var mock = new Mock<TClient>(ctorArgs) { CallBase = true };
+            mock.Protected().Setup<IRestClient>("BuildClient").Returns(result);
+            return mock.Object;
+        }
+
+        protected static TClient BuildSuccessMockClient<TClient, TResult>(string jsonResultFile, params object[] ctorArgs) where TResult : new() where TClient : Client
+        {
+            return BuildMockClient<TClient, TResult>(HttpStatusCode.OK, jsonResultFile, ctorArgs);
         }
     }
 }

--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -27,16 +27,16 @@ namespace Intercom.Clients
         {
         }
 
-        public ConversationPart Reply(AdminConversationReply reply)
+        public Conversation Reply(AdminConversationReply reply)
         {
             if (reply == null)
             {
                 throw new ArgumentNullException(nameof(reply));
             }
 
-            ClientResponse<ConversationPart> result = null;
+            ClientResponse<Conversation> result = null;
             String body = Serialize<AdminConversationReply>(reply);
-            result = Post<ConversationPart>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
+            result = Post<Conversation>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
             return result.Result;
         }
 

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -28,16 +28,16 @@ namespace Intercom.Clients
         {
         }
 
-        public ConversationPart Reply(UserConversationReply reply)
+        public Conversation Reply(UserConversationReply reply)
         {
             if (reply == null)
             {
                 throw new ArgumentNullException(nameof(reply));
             }
 
-            ClientResponse<ConversationPart> result = null;
+            ClientResponse<Conversation> result = null;
             String body = Serialize<UserConversationReply>(reply);
-            result = Post<ConversationPart>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
+            result = Post<Conversation>(body, resource: CONVERSATIONS_RESOURCE + Path.DirectorySeparatorChar + reply.conversation_id + Path.DirectorySeparatorChar + REPLY_RESOURCE);
             return result.Result;
         }
 


### PR DESCRIPTION
**Why?**
Updated model that's returned when replying to a message.

See [Docs](https://developers.intercom.com/intercom-api-reference/reference#replying-to-a-conversation)

**How?**
Simply changed the return value to be a a Conversation vs a ConversationPart as the documentation expects.