### PR TITLE
Ic added rest client factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ If you are building a third party application you will need to implement OAuth b
 
 ## Usage
 
+### For all client types
+
+It is now possible to create all types of client by either supplying the authentication object instance or by providing an instance of the new RestClientFactory. The latter is the new preferred method to construct instances of the various clients. The older constructor methods have been marked as obsolete and will be removed in later versions.
+
+```cs
+Authentication auth = new Authentication("MyPersonalAccessToken");
+RestClientFactory factory = new RestClientFactory(auth);
+UsersClient usersClient = new UsersClient(factory);
+```
+
 ### Users
 
 **Create UsersClient instance**

--- a/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
+++ b/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>3.0.0</ReleaseVersion>
+    <ReleaseVersion>2.2.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
+++ b/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>2.2.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
+++ b/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>2.0.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom.Tests/Clients/AdminClientTest.cs
+++ b/src/Intercom.Tests/Clients/AdminClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -20,7 +21,9 @@ namespace Intercom.Test
         public AdminClientTest()
             : base()
         {
-            this.adminsClient = new AdminsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            adminsClient = new AdminsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/AdminConversationsClientTest.cs
+++ b/src/Intercom.Tests/Clients/AdminConversationsClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -20,7 +21,9 @@ namespace Intercom.Test
 
         public AdminConversationsClientTest()
         {
-            this.adminConversationsClient = new AdminConversationsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            adminConversationsClient = new AdminConversationsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/CompanyClientTest.cs
+++ b/src/Intercom.Tests/Clients/CompanyClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public CompanyClientTest()
         {
-            this.companyClient = new CompanyClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            companyClient = new CompanyClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/ContactClientTest.cs
+++ b/src/Intercom.Tests/Clients/ContactClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -20,7 +21,9 @@ namespace Intercom.Test
         public ContactClientTest()
             : base()
         {
-            this.contactsClient = new ContactsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            contactsClient = new ContactsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/ConversationsClientTest.cs
+++ b/src/Intercom.Tests/Clients/ConversationsClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public ConversationsClientTest()
         {
-            this.conversationsClient = new ConversationsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            conversationsClient = new ConversationsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/EventsClientTest.cs
+++ b/src/Intercom.Tests/Clients/EventsClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public EventsClientTest()
         {
-            this.eventsClient = new EventsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            eventsClient = new EventsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/NotesClientTest.cs
+++ b/src/Intercom.Tests/Clients/NotesClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public NotesClientTest()
         {
-            this.notesClient = new NotesClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            notesClient = new NotesClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/TagsClientTest.cs
+++ b/src/Intercom.Tests/Clients/TagsClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public TagsClientTest()
         {
-            this.tagsClient = new TagsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            tagsClient = new TagsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/UserClientTest.cs
+++ b/src/Intercom.Tests/Clients/UserClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public UserClientTest()
         {
-            this.usersClient = new UsersClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            usersClient = new UsersClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Clients/UserClientTest.cs
+++ b/src/Intercom.Tests/Clients/UserClientTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Net;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
@@ -18,41 +19,71 @@ namespace Intercom.Test
     {
         private UsersClient usersClient;
 
-        public UserClientTest()
+        public UserClientTest() { }
+
+        private void SetupMock(RestClient restClient = null)
         {
             var auth = new Authentication(AppId, AppKey);
-            var restClientFactory = new RestClientFactory(auth);
+            if (restClient == null)
+            {
+                var restClientMock = new Mock<RestClient>();
+                restClient = restClientMock.Object;
+            }
+            var restClientFactoryMock = new Mock<RestClientFactory>(new object[] { auth });
+            restClientFactoryMock.Setup(x => x.RestClient).Returns(restClient);
+            var restClientFactory = restClientFactoryMock.Object;
             usersClient = new UsersClient(restClientFactory);
         }
 
         [Test()]
         public void Create_WithNull_ThrowException()
         {
+            SetupMock();
             Assert.Throws<ArgumentNullException>(() => usersClient.Create(null));
         }
 
         [Test()]
         public void Create_NoUserIdOrEmail_ThrowException()
         {
+            SetupMock();
             Assert.Throws<ArgumentException>(() => usersClient.Create(new User()));
         }
 
         [Test()]
         public void Archive_NoIdOrUserIdOrEmail_ThrowException()
         {
+            SetupMock();
             Assert.Throws<ArgumentException>(() => usersClient.Archive(new User()));
         }
 
         [Test()]
         public void PermanentlyDeleteUser_NoId_ThrowException()
         {
+            SetupMock();
             Assert.Throws<ArgumentNullException>(() => usersClient.PermanentlyDeleteUser(null));
         }
 
         [Test()]
         public void Update_NoIdOrUserIdOrEmail_ThrowException()
         {
+            SetupMock();
             Assert.Throws<ArgumentException>(() => usersClient.Update(new User()));
+        }
+
+        [Test()]
+        public void View_ByStringId_ReturnsObjectAsExpected()
+        {
+            var userId = "id";
+            var restClientMock = new Mock<RestClient>();
+            var restResponse = new RestResponse()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = $"{{ \"type\": \"user\", \"id\": \"530370b477ad7120001d\", \"user_id\": \"{userId}\", \"email\": \"wash@serenity.io\" }}",
+            };
+            restClientMock.Setup(x => x.Execute(It.IsAny<IRestRequest>())).Returns(restResponse);
+            var restClient = restClientMock.Object;
+            SetupMock(restClient);
+            Assert.AreEqual(userId, usersClient.View(userId).user_id);
         }
     }
 }

--- a/src/Intercom.Tests/Clients/UserConversationsClientTest.cs
+++ b/src/Intercom.Tests/Clients/UserConversationsClientTest.cs
@@ -4,6 +4,7 @@ using Intercom.Core;
 using Intercom.Data;
 using Intercom.Clients;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using System.Collections.Generic;
@@ -19,7 +20,9 @@ namespace Intercom.Test
 
         public UserConversationsClientTest()
         {
-            this.userConversationsClient = new UserConversationsClient(new Authentication(AppId, AppKey));
+            var auth = new Authentication(AppId, AppKey);
+            var restClientFactory = new RestClientFactory(auth);
+            userConversationsClient = new UserConversationsClient(restClientFactory);
         }
 
         [Test()]

--- a/src/Intercom.Tests/Intercom.Tests.csproj
+++ b/src/Intercom.Tests/Intercom.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>3.0.0</ReleaseVersion>
+    <ReleaseVersion>2.2.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom.Tests/Intercom.Tests.csproj
+++ b/src/Intercom.Tests/Intercom.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>2.2.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom.Tests/Intercom.Tests.csproj
+++ b/src/Intercom.Tests/Intercom.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <ReleaseVersion>2.0.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -17,13 +18,8 @@ namespace Intercom.Clients
         private const String MESSAGES_RESOURCE = "messages";
         private const String REPLY_RESOURCE = "reply";
 
-        public AdminConversationsClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
-        {
-        }
-
-        public AdminConversationsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
+        public AdminConversationsClient(RestClientFactory restClientFactory)
+            : base(CONVERSATIONS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -23,13 +23,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
         public AdminConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
         public AdminConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -23,13 +23,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
         public AdminConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
         public AdminConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/AdminConversationsClient.cs
+++ b/src/Intercom/Clients/AdminConversationsClient.cs
@@ -23,6 +23,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        public AdminConversationsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminConversationsClient(RestClientFactory restClientFactory)")]
+        public AdminConversationsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
         public ConversationPart Reply(AdminConversationReply reply)
         {
             if (reply == null)

--- a/src/Intercom/Clients/AdminsClient.cs
+++ b/src/Intercom/Clients/AdminsClient.cs
@@ -21,6 +21,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        public AdminsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, ADMINS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        public AdminsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, ADMINS_RESOURCE, authentication)
+        {
+        }
+
         public Admins List ()
         {
             ClientResponse<Admins> result = null;

--- a/src/Intercom/Clients/AdminsClient.cs
+++ b/src/Intercom/Clients/AdminsClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
         public AdminsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, ADMINS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
         public AdminsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, ADMINS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/AdminsClient.cs
+++ b/src/Intercom/Clients/AdminsClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
         public AdminsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, ADMINS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use AdminsClient(RestClientFactory restClientFactory)")]
         public AdminsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, ADMINS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/AdminsClient.cs
+++ b/src/Intercom/Clients/AdminsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -15,13 +16,8 @@ namespace Intercom.Clients
     {
         private const String ADMINS_RESOURCE = "admins";
 
-        public AdminsClient (Authentication authentication)
-            : base (INTERCOM_API_BASE_URL, ADMINS_RESOURCE, authentication)
-        {
-        }
-
-        public AdminsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, ADMINS_RESOURCE, authentication)
+        public AdminsClient (RestClientFactory restClientFactory)
+            : base (ADMINS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/CompanyClient.cs
+++ b/src/Intercom/Clients/CompanyClient.cs
@@ -19,13 +19,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
         public CompanyClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, COMPANIES_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
         public CompanyClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COMPANIES_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/CompanyClient.cs
+++ b/src/Intercom/Clients/CompanyClient.cs
@@ -19,13 +19,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
         public CompanyClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, COMPANIES_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
         public CompanyClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COMPANIES_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/CompanyClient.cs
+++ b/src/Intercom/Clients/CompanyClient.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
+using Intercom.Factories;
 using Newtonsoft.Json;
 
 namespace Intercom.Clients
@@ -13,13 +14,8 @@ namespace Intercom.Clients
     {
         private const String COMPANIES_RESOURCE = "companies";
 
-        public CompanyClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, COMPANIES_RESOURCE, authentication)
-        {
-        }
-
-        public CompanyClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COMPANIES_RESOURCE, authentication)
+        public CompanyClient(RestClientFactory restClientFactory)
+            : base(COMPANIES_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/CompanyClient.cs
+++ b/src/Intercom/Clients/CompanyClient.cs
@@ -19,6 +19,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        public CompanyClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, COMPANIES_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CompanyClient(RestClientFactory restClientFactory)")]
+        public CompanyClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COMPANIES_RESOURCE, authentication)
+        {
+        }
+
         public Company Create(Company company)
         {
             return CreateOrUpdate(company);

--- a/src/Intercom/Clients/ContactsClient.cs
+++ b/src/Intercom/Clients/ContactsClient.cs
@@ -25,6 +25,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        public ContactsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, CONTACTS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        public ContactsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONTACTS_RESOURCE, authentication)
+        {
+        }
+
         public Contact Create (Contact contact)
         {
             if (contact == null) {

--- a/src/Intercom/Clients/ContactsClient.cs
+++ b/src/Intercom/Clients/ContactsClient.cs
@@ -25,13 +25,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
         public ContactsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONTACTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
         public ContactsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONTACTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/ContactsClient.cs
+++ b/src/Intercom/Clients/ContactsClient.cs
@@ -25,13 +25,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
         public ContactsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONTACTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use ContactsClient(RestClientFactory restClientFactory)")]
         public ContactsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONTACTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/ContactsClient.cs
+++ b/src/Intercom/Clients/ContactsClient.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
+using Intercom.Factories;
 using Newtonsoft.Json;
 
 namespace Intercom.Clients
@@ -19,13 +20,8 @@ namespace Intercom.Clients
 
         private const String CONTACTS_RESOURCE = "contacts";
 
-        public ContactsClient (Authentication authentication)
-            : base (INTERCOM_API_BASE_URL, CONTACTS_RESOURCE, authentication)
-        {
-        }
-
-        public ContactsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONTACTS_RESOURCE, authentication)
+        public ContactsClient (RestClientFactory restClientFactory)
+            : base (CONTACTS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/ConversationsClient.cs
+++ b/src/Intercom/Clients/ConversationsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -24,13 +25,8 @@ namespace Intercom.Clients
 
         private const String CONVERSATIONS_RESOURCE = "conversations";
 
-        public ConversationsClient( Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
-        {
-        }
-
-        public ConversationsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
+        public ConversationsClient( RestClientFactory restClientFactory)
+            : base(CONVERSATIONS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/ConversationsClient.cs
+++ b/src/Intercom/Clients/ConversationsClient.cs
@@ -30,13 +30,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
         public ConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
         public ConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/ConversationsClient.cs
+++ b/src/Intercom/Clients/ConversationsClient.cs
@@ -30,6 +30,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        public ConversationsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        public ConversationsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
         public Conversation View(String id, bool? displayAsPlainText = null)
         {
             if (String.IsNullOrEmpty(id))

--- a/src/Intercom/Clients/ConversationsClient.cs
+++ b/src/Intercom/Clients/ConversationsClient.cs
@@ -30,13 +30,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
         public ConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use ConversationsClient(RestClientFactory restClientFactory)")]
         public ConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/CountsClient.cs
+++ b/src/Intercom/Clients/CountsClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
         public CountsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, COUNTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
         public CountsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COUNTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/CountsClient.cs
+++ b/src/Intercom/Clients/CountsClient.cs
@@ -21,6 +21,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        public CountsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, COUNTS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        public CountsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COUNTS_RESOURCE, authentication)
+        {
+        }
+
         public AppCount GetAppCount()
         {
             ClientResponse<AppCount> result = null;

--- a/src/Intercom/Clients/CountsClient.cs
+++ b/src/Intercom/Clients/CountsClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
         public CountsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, COUNTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use CountsClient(RestClientFactory restClientFactory)")]
         public CountsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COUNTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/CountsClient.cs
+++ b/src/Intercom/Clients/CountsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -15,13 +16,8 @@ namespace Intercom.Clients
     {
         private const String COUNTS_RESOURCE = "counts";
 
-        public CountsClient (Authentication authentication)
-            : base (INTERCOM_API_BASE_URL, COUNTS_RESOURCE, authentication)
-        {
-        }
-
-        public CountsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COUNTS_RESOURCE, authentication)
+        public CountsClient (RestClientFactory restClientFactory)
+            : base (COUNTS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/EventClient.cs
+++ b/src/Intercom/Clients/EventClient.cs
@@ -6,6 +6,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -15,15 +16,10 @@ namespace Intercom.Clients
 	{
 		private const String COMPANIES_RESOURCE = "events";
 
-		public EventsClient (Authentication authentication)
-			: base (INTERCOM_API_BASE_URL, COMPANIES_RESOURCE, authentication)
+		public EventsClient (RestClientFactory restClientFactory)
+			: base (COMPANIES_RESOURCE, restClientFactory)
 		{
 		}
-
-        public EventsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, COMPANIES_RESOURCE, authentication)
-        {
-        }
 
 		public Event Create (Event @event)
 		{

--- a/src/Intercom/Clients/EventClient.cs
+++ b/src/Intercom/Clients/EventClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
 		{
 		}
 
-		[Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+		[Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
         public EventsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, EVENTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
         public EventsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, EVENTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/EventClient.cs
+++ b/src/Intercom/Clients/EventClient.cs
@@ -14,12 +14,24 @@ namespace Intercom.Clients
 {
 	public class EventsClient : Client
 	{
-		private const String COMPANIES_RESOURCE = "events";
+		private const String EVENTS_RESOURCE = "events";
 
 		public EventsClient (RestClientFactory restClientFactory)
-			: base (COMPANIES_RESOURCE, restClientFactory)
+			: base (EVENTS_RESOURCE, restClientFactory)
 		{
 		}
+
+		[Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+        public EventsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, EVENTS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+        public EventsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, EVENTS_RESOURCE, authentication)
+        {
+        }
 
 		public Event Create (Event @event)
 		{

--- a/src/Intercom/Clients/EventClient.cs
+++ b/src/Intercom/Clients/EventClient.cs
@@ -21,13 +21,13 @@ namespace Intercom.Clients
 		{
 		}
 
-		[Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+		[Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
         public EventsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, EVENTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use EventsClient(RestClientFactory restClientFactory)")]
         public EventsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, EVENTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/NotesClient.cs
+++ b/src/Intercom/Clients/NotesClient.cs
@@ -7,6 +7,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using Newtonsoft.Json;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -17,13 +18,8 @@ namespace Intercom.Clients
     {
         private const String NOTES_RESOURCE = "notes";
 
-        public NotesClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, NOTES_RESOURCE, authentication)
-        {
-        }
-
-        public NotesClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, NOTES_RESOURCE, authentication)
+        public NotesClient(RestClientFactory restClientFactory)
+            : base(NOTES_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/NotesClient.cs
+++ b/src/Intercom/Clients/NotesClient.cs
@@ -23,6 +23,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        public NotesClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, NOTES_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        public NotesClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, NOTES_RESOURCE, authentication)
+        {
+        }
+
         public Note Create(Note note)
         {
             if (note == null)

--- a/src/Intercom/Clients/NotesClient.cs
+++ b/src/Intercom/Clients/NotesClient.cs
@@ -23,13 +23,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
         public NotesClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, NOTES_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
         public NotesClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, NOTES_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/NotesClient.cs
+++ b/src/Intercom/Clients/NotesClient.cs
@@ -23,13 +23,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
         public NotesClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, NOTES_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use NotesClient(RestClientFactory restClientFactory)")]
         public NotesClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, NOTES_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/SegmentsClient.cs
+++ b/src/Intercom/Clients/SegmentsClient.cs
@@ -20,6 +20,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        public SegmentsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, SEGMENTS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        public SegmentsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, SEGMENTS_RESOURCE, authentication)
+        {
+        }
+
         public Segments List(bool company = false)
         {
             ClientResponse<Segments> result = null;

--- a/src/Intercom/Clients/SegmentsClient.cs
+++ b/src/Intercom/Clients/SegmentsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 
 namespace Intercom.Clients
@@ -14,13 +15,8 @@ namespace Intercom.Clients
     {
         private const String SEGMENTS_RESOURCE = "segments";
 
-        public SegmentsClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, SEGMENTS_RESOURCE, authentication)
-        {
-        }
-
-        public SegmentsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, SEGMENTS_RESOURCE, authentication)
+        public SegmentsClient(RestClientFactory restClientFactory)
+            : base(SEGMENTS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/SegmentsClient.cs
+++ b/src/Intercom/Clients/SegmentsClient.cs
@@ -20,13 +20,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
         public SegmentsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, SEGMENTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
         public SegmentsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, SEGMENTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/SegmentsClient.cs
+++ b/src/Intercom/Clients/SegmentsClient.cs
@@ -20,13 +20,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
         public SegmentsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, SEGMENTS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use SegmentsClient(RestClientFactory restClientFactory)")]
         public SegmentsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, SEGMENTS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/TagsClient.cs
+++ b/src/Intercom/Clients/TagsClient.cs
@@ -29,13 +29,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
         public TagsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, TAGS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
         public TagsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, TAGS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/TagsClient.cs
+++ b/src/Intercom/Clients/TagsClient.cs
@@ -29,13 +29,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
         public TagsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, TAGS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
         public TagsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, TAGS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/TagsClient.cs
+++ b/src/Intercom/Clients/TagsClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using Newtonsoft.Json;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -23,13 +24,8 @@ namespace Intercom.Clients
 
         private const String TAGS_RESOURCE = "tags";
 
-        public TagsClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, TAGS_RESOURCE, authentication)
-        {
-        }
-
-        public TagsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, TAGS_RESOURCE, authentication)
+        public TagsClient(RestClientFactory restClientFactory)
+            : base(TAGS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/TagsClient.cs
+++ b/src/Intercom/Clients/TagsClient.cs
@@ -29,6 +29,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        public TagsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, TAGS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use TagsClient(RestClientFactory restClientFactory)")]
+        public TagsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, TAGS_RESOURCE, authentication)
+        {
+        }
+
         public Tag Create(Tag tag)
         {
             if (tag == null)

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -7,6 +7,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -18,16 +19,10 @@ namespace Intercom.Clients
         private const String MESSAGES_RESOURCE = "messages";
         private const String REPLY_RESOURCE = "reply";
 
-        public UserConversationsClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
+        public UserConversationsClient(RestClientFactory restClientFactory)
+            : base(CONVERSATIONS_RESOURCE, restClientFactory)
         {
         }
-
-        public UserConversationsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
-        {
-        }
-
         public ConversationPart Reply(UserConversationReply reply)
         {
             if (reply == null)

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -24,13 +24,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
         public UserConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
         public UserConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -23,6 +23,19 @@ namespace Intercom.Clients
             : base(CONVERSATIONS_RESOURCE, restClientFactory)
         {
         }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        public UserConversationsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        public UserConversationsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
+        {
+        }
+
         public ConversationPart Reply(UserConversationReply reply)
         {
             if (reply == null)

--- a/src/Intercom/Clients/UserConversationsClient.cs
+++ b/src/Intercom/Clients/UserConversationsClient.cs
@@ -24,13 +24,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
         public UserConversationsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, CONVERSATIONS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use UserConversationsClient(RestClientFactory restClientFactory)")]
         public UserConversationsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, CONVERSATIONS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -32,13 +32,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
         public UsersClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, USERS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
         public UsersClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, USERS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -32,6 +32,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        public UsersClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, USERS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        public UsersClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, USERS_RESOURCE, authentication)
+        {
+        }
+
         public User Create(User user)
         {
             if (user == null)

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -7,6 +7,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using Newtonsoft.Json;
@@ -26,13 +27,8 @@ namespace Intercom.Clients
         private const String USERS_RESOURCE = "users";
         private const String PERMANENT_DELETE_RESOURCE = "user_delete_requests";
 
-        public UsersClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, USERS_RESOURCE, authentication)
-        {
-        }
-
-        public UsersClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, USERS_RESOURCE, authentication)
+        public UsersClient(RestClientFactory restClientFactory)
+            : base(USERS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -32,13 +32,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
         public UsersClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, USERS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use UsersClient(RestClientFactory restClientFactory)")]
         public UsersClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, USERS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -288,7 +288,7 @@ namespace Intercom.Clients
             else if (!String.IsNullOrEmpty(user.email))
                 body = JsonConvert.SerializeObject(new { email = user.email, last_request_at = timestamp });
             else
-                throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to update a user's last seet at.");
+                throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to update a user's last seen at.");
 
             ClientResponse<User> result = null;
             result = Post<User>(body);
@@ -324,7 +324,7 @@ namespace Intercom.Clients
             else if (!String.IsNullOrEmpty(user.email))
                 body = JsonConvert.SerializeObject(new { email = user.email, update_last_request_at = true });
             else
-                throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to update a user's last seet at.");
+                throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to update a user's last seen at.");
 
             ClientResponse<User> result = null;
             result = Post<User>(body);

--- a/src/Intercom/Clients/VisitorsClient.cs
+++ b/src/Intercom/Clients/VisitorsClient.cs
@@ -24,6 +24,18 @@ namespace Intercom.Clients
         {
         }
 
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        public VisitorsClient(Authentication authentication)
+            : base(INTERCOM_API_BASE_URL, VISITORS_RESOURCE, authentication)
+        {
+        }
+
+        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        public VisitorsClient(String intercomApiUrl, Authentication authentication)
+            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, VISITORS_RESOURCE, authentication)
+        {
+        }
+
         public Visitor View(Dictionary<String, String> parameters)
         {
             if (parameters == null)

--- a/src/Intercom/Clients/VisitorsClient.cs
+++ b/src/Intercom/Clients/VisitorsClient.cs
@@ -7,6 +7,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using RestSharp;
 using RestSharp.Authenticators;
 using Newtonsoft.Json;
@@ -18,13 +19,8 @@ namespace Intercom.Clients
         private const String VISITORS_RESOURCE = "visitors";
         private const String VISITORS_CONVERT = "convert";
 
-        public VisitorsClient(Authentication authentication)
-            : base(INTERCOM_API_BASE_URL, VISITORS_RESOURCE, authentication)
-        {
-        }
-
-        public VisitorsClient(String intercomApiUrl, Authentication authentication)
-            : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, VISITORS_RESOURCE, authentication)
+        public VisitorsClient(RestClientFactory restClientFactory)
+            : base(VISITORS_RESOURCE, restClientFactory)
         {
         }
 

--- a/src/Intercom/Clients/VisitorsClient.cs
+++ b/src/Intercom/Clients/VisitorsClient.cs
@@ -24,13 +24,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
         public VisitorsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, VISITORS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.1.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
         public VisitorsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, VISITORS_RESOURCE, authentication)
         {

--- a/src/Intercom/Clients/VisitorsClient.cs
+++ b/src/Intercom/Clients/VisitorsClient.cs
@@ -24,13 +24,13 @@ namespace Intercom.Clients
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
         public VisitorsClient(Authentication authentication)
             : base(INTERCOM_API_BASE_URL, VISITORS_RESOURCE, authentication)
         {
         }
 
-        [Obsolete("This constructor is deprecated as of 2.2.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
+        [Obsolete("This constructor is deprecated as of 3.0.0 and will soon be removed, please use VisitorsClient(RestClientFactory restClientFactory)")]
         public VisitorsClient(String intercomApiUrl, Authentication authentication)
             : base(String.IsNullOrEmpty(intercomApiUrl) ? INTERCOM_API_BASE_URL : intercomApiUrl, VISITORS_RESOURCE, authentication)
         {

--- a/src/Intercom/Core/Client.cs
+++ b/src/Intercom/Core/Client.cs
@@ -7,6 +7,7 @@ using Intercom.Clients;
 using Intercom.Core;
 using Intercom.Data;
 using Intercom.Exceptions;
+using Intercom.Factories;
 using Newtonsoft;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,7 +18,6 @@ namespace Intercom.Core
 {
     public class Client
     {
-        protected const String INTERCOM_API_BASE_URL = "https://api.intercom.io/";
         protected const String CONTENT_TYPE_HEADER = "Content-Type";
         protected const String CONTENT_TYPE_VALUE = "application/json";
         protected const String ACCEPT_HEADER = "Accept";
@@ -27,24 +27,19 @@ namespace Intercom.Core
         protected const String USER_AGENT_HEADER = "User-Agent";
         protected const String USER_AGENT_VALUE = "intercom-dotnet/2.0.0";
 
-        protected readonly String URL;
         protected readonly String RESRC;
-        protected readonly Authentication AUTH;
+        protected readonly RestClientFactory _restClientFactory;
 
-        public Client(String url, String resource, Authentication authentication)
+        public Client(String resource, RestClientFactory restClientFactory)
         {
-            if (authentication == null)
-                throw new ArgumentNullException(nameof(authentication));
-                
-            if (String.IsNullOrEmpty(url))
-                throw new ArgumentNullException(nameof(url));
+            if (restClientFactory == null)
+                throw new ArgumentNullException(nameof(restClientFactory));
 
             if (String.IsNullOrEmpty(resource))
                 throw new ArgumentNullException(nameof(resource));
 
-            this.URL = url;
-            this.RESRC = resource;
-            this.AUTH = authentication;
+            RESRC = resource;
+            _restClientFactory = restClientFactory;
         }
 
         protected virtual ClientResponse<T> Get<T>(
@@ -55,9 +50,10 @@ namespace Intercom.Core
         {
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.GET, headers: headers, parameters: parameters, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse<T>(response);
@@ -74,7 +70,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}",
-                        "GET", URL, RESRC, resource), ex); 
+                        "GET", client.BaseUrl, RESRC, resource), ex); 
             }
 
             return clientResponse;
@@ -93,9 +89,10 @@ namespace Intercom.Core
 
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.POST, headers: headers, parameters: parameters, body: body, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse <T>(response);
@@ -112,7 +109,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}, Body: {4}",
-                        "POST", URL, RESRC, resource, body), ex); 
+                        "POST", client.BaseUrl, RESRC, resource, body), ex); 
             }
 
             return clientResponse;
@@ -131,10 +128,11 @@ namespace Intercom.Core
 
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
                 String requestBody = Serialize<T>(body);
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.POST, headers: headers, parameters: parameters, body: requestBody, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse <T>(response);
@@ -151,7 +149,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}, Body-Type: {4}",
-                        "POST", URL, RESRC, resource, typeof(T)), ex); 
+                        "POST", client.BaseUrl, RESRC, resource, typeof(T)), ex); 
             }
 
             return clientResponse;
@@ -170,9 +168,10 @@ namespace Intercom.Core
 
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.PUT, headers: headers, parameters: parameters, body: body, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse <T>(response);
@@ -189,7 +188,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}, Body: {4}",
-                        "POST", URL, RESRC, resource, body), ex); 
+                        "POST", client.BaseUrl, RESRC, resource, body), ex); 
             }
 
             return clientResponse;
@@ -208,10 +207,11 @@ namespace Intercom.Core
 
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
                 String requestBody = Serialize<T>(body);
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.PUT, headers: headers, parameters: parameters, body: requestBody, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse <T>(response);
@@ -228,7 +228,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}",
-                        "POST", URL, RESRC, resource), ex); 
+                        "POST", client.BaseUrl, RESRC, resource), ex); 
             }
 
             return clientResponse;
@@ -242,9 +242,10 @@ namespace Intercom.Core
         {
             ClientResponse<T> clientResponse = null;
 
+            IRestClient client = null;
             try
             {
-                IRestClient client = BuildClient();
+                client = BuildClient();
                 IRestRequest request = BuildRequest(httpMethod: Method.DELETE, headers: headers, parameters: parameters, resource: resource);
                 IRestResponse response = client.Execute(request);
                 clientResponse = HandleResponse<T>(response);
@@ -261,7 +262,7 @@ namespace Intercom.Core
             {
                 throw new IntercomException(String.Format("An exception occurred " +
                         "while calling the endpoint. Method: {0}, Url: {1}, Resource: {2}, Sub-Resource: {3}",
-                        "POST", URL, RESRC, resource), ex); 
+                        "POST", client.BaseUrl, RESRC, resource), ex); 
             }
         
             return clientResponse;
@@ -295,14 +296,7 @@ namespace Intercom.Core
 
         protected virtual IRestClient BuildClient()
         {
-            RestClient client = new RestClient(URL);
-
-            if (!String.IsNullOrEmpty (AUTH.AppId) && !String.IsNullOrEmpty (AUTH.AppKey))
-                client.Authenticator = new HttpBasicAuthenticator (AUTH.AppId, AUTH.AppKey);
-            else
-                client.Authenticator = new HttpBasicAuthenticator (AUTH.PersonalAccessToken, String.Empty);
-
-            return client;
+            return _restClientFactory.RestClient;
         }
 
         protected virtual void AddHeaders(IRestRequest request, 

--- a/src/Intercom/Core/Client.cs
+++ b/src/Intercom/Core/Client.cs
@@ -18,6 +18,7 @@ namespace Intercom.Core
 {
     public class Client
     {
+        protected const String INTERCOM_API_BASE_URL = "https://api.intercom.io/";
         protected const String CONTENT_TYPE_HEADER = "Content-Type";
         protected const String CONTENT_TYPE_VALUE = "application/json";
         protected const String ACCEPT_HEADER = "Accept";
@@ -40,6 +41,21 @@ namespace Intercom.Core
 
             RESRC = resource;
             _restClientFactory = restClientFactory;
+        }
+
+        public Client(String intercomApiUrl, String resource, Authentication authentication)
+        {
+            if (authentication == null)
+                throw new ArgumentNullException(nameof(authentication));
+
+            if (String.IsNullOrEmpty(resource))
+                throw new ArgumentNullException(nameof(resource));
+
+            if (String.IsNullOrEmpty(intercomApiUrl))
+                throw new ArgumentNullException(nameof(intercomApiUrl));
+
+            RESRC = resource;
+            _restClientFactory = new RestClientFactory(authentication, intercomApiUrl);
         }
 
         protected virtual ClientResponse<T> Get<T>(

--- a/src/Intercom/Factories/RestClientFactory.cs
+++ b/src/Intercom/Factories/RestClientFactory.cs
@@ -13,6 +13,8 @@ namespace Intercom.Factories
         private readonly string _url;
         private IRestClient _restClient;
 
+        private readonly object padlock = new object();
+
         public RestClientFactory(Authentication authentication)
         {
             _authentication = authentication;
@@ -29,12 +31,15 @@ namespace Intercom.Factories
         {
             get
             {
-                if (_restClient != null)
+                lock(padlock)
                 {
-                    return _restClient;
+                    if (_restClient != null)
+                    {
+                        return _restClient;
+                    }
+                    ConstructClient();
+                    return _restClient; 
                 }
-                ConstructClient();
-                return _restClient; 
             }
         }
 

--- a/src/Intercom/Factories/RestClientFactory.cs
+++ b/src/Intercom/Factories/RestClientFactory.cs
@@ -1,0 +1,48 @@
+using System;
+using RestSharp;
+using RestSharp.Authenticators;
+using Intercom.Core;
+
+namespace Intercom.Factories
+{
+    public class RestClientFactory
+    {
+
+        protected const String INTERCOM_API_BASE_URL = "https://api.intercom.io/";
+
+        private readonly Authentication _authentication;
+        private readonly string _url;
+        private IRestClient _restClient;
+
+        public RestClientFactory(Authentication authentication, string url = INTERCOM_API_BASE_URL)
+        {
+            _authentication = authentication;
+            _url = url;
+        }
+
+        public IRestClient RestClient
+        {
+            get
+            {
+                if (_restClient != null)
+                {
+                    return _restClient;
+                }
+                ConstructClient();
+                return _restClient; 
+            }
+        }
+
+        private void ConstructClient()
+        {
+            RestClient client = new RestClient(_url);
+
+            if (!String.IsNullOrEmpty (_authentication.AppId) && !String.IsNullOrEmpty (_authentication.AppKey))
+                client.Authenticator = new HttpBasicAuthenticator (_authentication.AppId, _authentication.AppKey);
+            else
+                client.Authenticator = new HttpBasicAuthenticator (_authentication.PersonalAccessToken, String.Empty);
+
+            _restClient = client;
+        }
+    }
+}

--- a/src/Intercom/Factories/RestClientFactory.cs
+++ b/src/Intercom/Factories/RestClientFactory.cs
@@ -14,13 +14,19 @@ namespace Intercom.Factories
         private readonly string _url;
         private IRestClient _restClient;
 
-        public RestClientFactory(Authentication authentication, string url = INTERCOM_API_BASE_URL)
+        public RestClientFactory(Authentication authentication)
+        {
+            _authentication = authentication;
+            _url = INTERCOM_API_BASE_URL;
+        }
+
+        public RestClientFactory(Authentication authentication, string url)
         {
             _authentication = authentication;
             _url = url;
         }
 
-        public IRestClient RestClient
+        public virtual IRestClient RestClient
         {
             get
             {

--- a/src/Intercom/Factories/RestClientFactory.cs
+++ b/src/Intercom/Factories/RestClientFactory.cs
@@ -8,8 +8,7 @@ namespace Intercom.Factories
     public class RestClientFactory
     {
 
-        protected const String INTERCOM_API_BASE_URL = "https://api.intercom.io/";
-
+        private const String INTERCOM_API_BASE_URL = "https://api.intercom.io/";
         private readonly Authentication _authentication;
         private readonly string _url;
         private IRestClient _restClient;

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>3.0.0</ReleaseVersion>
+    <ReleaseVersion>2.2.0</ReleaseVersion>
     <PackageId>Intercom.Dotnet.Client</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
     <Owners>Intercom</Owners>

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.2.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
     <PackageId>Intercom.Dotnet.Client</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
     <Owners>Intercom</Owners>

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.0.0</ReleaseVersion>
+    <ReleaseVersion>3.0.0</ReleaseVersion>
     <PackageId>Intercom.Dotnet.Client</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
     <Owners>Intercom</Owners>

--- a/src/Intercom/intercom.nuspec
+++ b/src/Intercom/intercom.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Intercom.Dotnet.Client</id>
     <title>Intercom Dotnet Client</title>
-    <version>3.0.0</version>
+    <version>2.2.0</version>
     <authors>Intercom</authors>
     <owners>Intercom</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Intercom/intercom.nuspec
+++ b/src/Intercom/intercom.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Intercom.Dotnet.Client</id>
     <title>Intercom Dotnet Client</title>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
     <authors>Intercom</authors>
     <owners>Intercom</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Intercom/intercom.nuspec
+++ b/src/Intercom/intercom.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Intercom.Dotnet.Client</id>
     <title>Intercom Dotnet Client</title>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <authors>Intercom</authors>
     <owners>Intercom</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
#### Why?
- The existing architecture that we had made it very hard to test what was going on with the clients
- With each client in charge of constructing their own RestSharp clients, there was no way to mock server responses to test the parsing logic.
- I think this kind of breaking change would be a major version bump
#### How?
- Introduced the concept of a factory for RestSharp client instances.
- Made all clients take this as a single dependency.
- Used this to dependency to mock the RestSharp clients comms with the server.
- Added single POC test for viewing a user illustrating the usage of the mock and our new ability to test the output of the client.
- Bumped version to 3.0.0
