### PR TITLE
Fixing UsersClient.View when searching with parameters

### DIFF
--- a/src/Intercom/Clients/UsersClient.cs
+++ b/src/Intercom/Clients/UsersClient.cs
@@ -115,10 +115,10 @@ namespace Intercom.Clients
                 throw new ArgumentException("'parameters' argument should include user_id parameter.");
             }
 
-            ClientResponse<User> result = null;
+            ClientResponse<Users> result = null;
 
-            result = Get<User>(parameters: parameters);
-            return result.Result;
+            result = Get<Users>(parameters: parameters);
+            return result.Result.users.FirstOrDefault();
         }
 
         public User View(String id)
@@ -141,28 +141,26 @@ namespace Intercom.Clients
             }
 
             Dictionary<String, String> parameters = new Dictionary<string, string>();
-            ClientResponse<User> result = null;
 
             if (!String.IsNullOrEmpty(user.id))
             {
-                result = Get<User>(resource: USERS_RESOURCE + Path.DirectorySeparatorChar + user.id);
-            }
-            else if (!String.IsNullOrEmpty(user.user_id))
+                return Get<User>(resource: USERS_RESOURCE + Path.DirectorySeparatorChar + user.id).Result;
+            } 
+            
+            if (!String.IsNullOrEmpty(user.user_id))
             {
                 parameters.Add(Constants.USER_ID, user.user_id);
-                result = Get<User>(parameters: parameters);
+                return Get<Users>(parameters: parameters).Result.users.FirstOrDefault();
             }
-            else if (!String.IsNullOrEmpty(user.email))
+            
+            if (!String.IsNullOrEmpty(user.email))
             {
                 parameters.Add(Constants.EMAIL, user.email);
-                result = Get<User>(parameters: parameters);
+                return Get<Users>(parameters: parameters).Result.users.FirstOrDefault();;
             }
-            else
-            {
-                throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to view a user.");
-            }
-
-            return result.Result;
+            
+            throw new ArgumentException("you need to provide either 'user.id', 'user.user_id', 'user.email' to view a user.");
+            
         }
 
         public Users List()


### PR DESCRIPTION
#### Why?
/user?param=parameters enpoint returns a list of users, not a single user.

Because of this UsersClient.View is broken and always returns an object with all null values unless you search by id because /users/{id} is the endpoint that returns a single user.

#### How?
When querying by params (ie by user_id={user_id} or email={email}) return {resultObject}.users.FirstOrDefault() instead of {resultObject}

#### Investigate
I could only test this for the /users/email={email} endpoint, as our user_ids are empty, but I am assuming they work the same way.
Is /users/email={email} supposed to only return a single user? Is THAT the issue here? Or was that updated and the docs/packages werent?
https://developers.intercom.com/intercom-api-reference/reference#view-a-user
