### PR TITLE
Fix paginated contact list deserialization

### DIFF
--- a/src/Intercom/Data/Next.cs
+++ b/src/Intercom/Data/Next.cs
@@ -1,0 +1,8 @@
+﻿namespace Intercom.Data
+{
+	public class Next
+	{
+		public int page { get; set; }
+		public string starting_after { get; set; }
+	}
+}

--- a/src/Intercom/Data/Pages.cs
+++ b/src/Intercom/Data/Pages.cs
@@ -1,18 +1,10 @@
-﻿using System;
-using Intercom.Core;
-using Intercom.Data;
-
-
-using Intercom.Clients;
-
-using Intercom.Exceptions;
-
+﻿using Intercom.Core;
 
 namespace Intercom.Data
 {
 	public class Pages : Model
 	{
-		public string next { get; set; }
+		public Next next { get; set; }
 		public int page { get; set; }
 		public int per_page { get; set; }
 		public int total_pages { get; set; }


### PR DESCRIPTION
#### Why?
ContactsClient.List() returns JSON that can't be deserialized. Specifically, the next object:
``` JSON
{
    "type": "list",
    "data": [ ],
    "pages": {
        "type": "pages",
        "next": {
            "page": 2,
            "starting_after": "WzE1ODk0NjU0NTkwMDAsIjVjOTBjYTg0NjQxNjBjMTc2OTFmOThhZiIsMl0="
        },
        "page": 1,
        "per_page": 10,
        "total_pages": 27
    }
}
```
#### How?
This PR adds Next.cs and uses it instead of a string for the type of next in Pages.cs