### PR TITLE
.NET Standard 2.0 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
     docker:
-      - image: microsoft/dotnet:2-sdk
+      - image: mcr.microsoft.com/dotnet/sdk:3.1
       
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 Run the nuget command for installing the client as `Install-Package Intercom.Dotnet.Client`
 
+## Supported Platforms
+
+* [.NET Standard 2.0](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) or greater
+
 ## Resources
 
 Resources this API supports:

--- a/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
+++ b/src/Intercom.Tests.Integration/Intercom.Tests.Integration.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
     <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Intercom\Intercom.csproj" />

--- a/src/Intercom.Tests/Intercom.Tests.csproj
+++ b/src/Intercom.Tests/Intercom.Tests.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
     <ReleaseVersion>3.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="RestSharp" Version="106.5.4" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Intercom\Intercom.csproj" />

--- a/src/Intercom/Intercom.csproj
+++ b/src/Intercom/Intercom.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <ReleaseVersion>3.0.0</ReleaseVersion>
     <PackageId>Intercom.Dotnet.Client</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/intercom/intercom-dotnet/master/src/assets/Intercom.png</PackageIconUrl>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="RestSharp" Version="106.5.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
#### Why?
- At the time, current nuget package ([2.1.1](https://www.nuget.org/packages/Intercom.Dotnet.Client/)) does not support netstandard installations. 
- Tests projects are targeting against "netcore2.0" which already hit EOL. 
- Adding support to full framework 4.5.2 on https://github.com/intercom/intercom-dotnet/pull/147 has broken CircleCI builds
- full framework 4.5.2 [has lost official support on past April 26 ](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-framework#sha1-retirement)
- If we want to add full netstandard2.0 support, nugets must be updated, making 4.5.2 support really difficult

#### How?
- Updated netcore2.0 to netcore3.1 (LTS support) on tests projects
- Removed net452 as a second target framework in the .csproj files
- Updated referenced NuGet packages
- Fixed CircleCI builds (using new docker image)

------

[.NET standard 2.0 supports](https://github.com/dotnet/standard/blob/master/docs/versions/netstandard2.0.md#platform-support): 

- .NET Core 2.0
- .NET Framework 4.6.1
- Mono 5.4
- Xamarin.iOS 10.14
- Xamarin.Mac 3.8
- Xamarin.Android 8.0
- Universal Windows Platform 10.0.16299

